### PR TITLE
COP-5617 - Remove z-index as it is making button unclickable

### DIFF
--- a/src/templates/gds/file/form.ejs
+++ b/src/templates/gds/file/form.ejs
@@ -20,7 +20,7 @@
     {% ctx.files.forEach(function(file) { %}
         <tr class="govuk-table__row">
             {% if (!ctx.disabled) { %}
-            <td class="govuk-table__cell"><button class="govuk-button govuk-button--warning govuk-!-margin-bottom-0" style="z-index: -1;" ref="removeLink">Remove</button></td>
+            <td class="govuk-table__cell"><button class="govuk-button govuk-button--warning govuk-!-margin-bottom-0" ref="removeLink">Remove</button></td>
             {% } %}
             <td class="govuk-table__cell">
                 {% if (ctx.component.uploadOnly) { %}
@@ -59,7 +59,7 @@
         {% ctx.files.forEach(function(file) { %}
         <tr class="govuk-table__row">
         {% if (!ctx.disabled) { %}
-          <td class="govuk-table__cell"><button class="govuk-button govuk-button--warning govuk-!-margin-bottom-0" style="z-index: -1;" ref="removeLink">Remove</button></td>
+          <td class="govuk-table__cell"><button class="govuk-button govuk-button--warning govuk-!-margin-bottom-0" ref="removeLink">Remove</button></td>
         {% } %}
          <td class="govuk-table__cell">
           <img ref="fileImage" src="" alt="{{file.originalName || file.name}}" style="width:{{ctx.component.imageSize}}px">


### PR DESCRIPTION
## AC

Make the remove button clickable when you've added a file

## Updated

Removed the z-index that was set for that element as it was causing the button to move down under the table and therefore wasn't clickable