### PR TITLE
Applied disabled styling to .govuk-textarea

### DIFF
--- a/src/templates/gds/template.scss
+++ b/src/templates/gds/template.scss
@@ -42,7 +42,7 @@
   color: white;
 }
 
-.govuk-input:disabled, .form-control:disabled, .form-control[readonly] {
+.govuk-input:disabled, .govuk-textarea:disabled, .form-control:disabled, .form-control[readonly] {
   background-color: #e9ecef;
   opacity: 1;
 };


### PR DESCRIPTION
Signed-off-by: Andrew Scrivener <andrew.scrivener@digital.homeoffice.gov.uk>

This is a minor change to fix the missing disabled styles to text areas within Formbuilder.